### PR TITLE
Bootstrap Cloud Run job deployment for a01_obb_pullDaily

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -1,0 +1,60 @@
+name: CI Deploy a01_obb_pullDaily
+
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      IMAGE: ${{ secrets.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT }}/trading/app:${{ github.sha }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT }}
+
+      - name: Configure Docker for Artifact Registry
+        run: |
+          gcloud auth configure-docker ${{ secrets.GCP_REGION }}-docker.pkg.dev --quiet
+
+      - name: Build container image
+        run: |
+          docker build -t "$IMAGE" a_apps/a01_obb_pullDaily
+
+      - name: Push container image
+        run: |
+          docker push "$IMAGE"
+
+      - name: Deploy Cloud Run Job
+        run: |
+          gcloud run jobs deploy a01-obb-pullDaily \
+            --image "$IMAGE" \
+            --region "${{ secrets.GCP_REGION }}" \
+            --service-account "${{ secrets.RUNTIME_SA_EMAIL }}" \
+            --set-env-vars "DRY_RUN=true,PROJECT_ID=${{ secrets.GCP_PROJECT }}"
+
+      - name: Execute Cloud Run Job
+        run: |
+          gcloud run jobs execute a01-obb-pullDaily \
+            --region "${{ secrets.GCP_REGION }}" \
+            --wait

--- a/a_apps/a01_obb_pullDaily/Dockerfile
+++ b/a_apps/a01_obb_pullDaily/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY main.py /app/main.py
+
+CMD ["python", "/app/main.py"]

--- a/a_apps/a01_obb_pullDaily/main.py
+++ b/a_apps/a01_obb_pullDaily/main.py
@@ -1,0 +1,26 @@
+import json
+import os
+from datetime import datetime, timezone
+
+
+def build_payload() -> dict:
+    dry_run = os.getenv("DRY_RUN", "")
+    project_id = os.getenv("PROJECT_ID", "")
+
+    return {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "msg": "a01_obb_pullDaily DRY_RUN" if dry_run.lower() == "true" else "a01_obb_pullDaily",  # noqa: E501
+        "env": {
+            "DRY_RUN": dry_run,
+            "PROJECT_ID": project_id,
+        },
+    }
+
+
+def main() -> None:
+    payload = build_payload()
+    print(json.dumps(payload))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Patch Map
- add the a01_obb_pullDaily application entrypoint that emits structured runtime details.
- containerize the job with a slim Python 3.11 image ready for Cloud Run execution.
- wire a CI workflow that builds, pushes, deploys, and executes the Cloud Run job via Artifact Registry.

## Test/CI notes
- `python -m compileall a_apps/a01_obb_pullDaily/main.py`

## Rollback
- Revert this PR and delete the Cloud Run job or images created by the workflow if deployed.

## Security
- Uses GitHub OIDC (workload identity federation) for gcloud access without any static service account keys.


------
https://chatgpt.com/codex/tasks/task_e_68cdd0af169c83219128c076dd39c659