### PR TITLE
Add Google Sheet smoke write verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Option-C (Now)                  Threshold Gatekeeper                  Option-A (
 - **Why:** Single source of truth for your early PoC; later we may split raw vs features for scale.
 - **Secrets:** `SHEET_ID`, `GCP_PROJECT`, `GCP_WIF_PROVIDER`, `RUNTIME_SA_EMAIL`, `GCP_REGION`.
 - **Share:** Give Editor access to `${RUNTIME_SA_EMAIL}` on the Sheet.
+- **Smoke write:** Run `python tools/verify/smoke_sheet_write.py` with `SHEET_ID` exported and optionally `SHEET_TAB`/`SHEET_CELL`/`SHEET_VALUE`. Defaults write the UTC timestamp into tab `smoke`, cell `A1` so you can confirm the service account has edit rights without touching production tabs.
 
 Run (manual):
 1. GitHub → Actions → **a01_bsp_pullDaily_sheet_full** → **Run workflow**

--- a/tools/verify/smoke_sheet_write.py
+++ b/tools/verify/smoke_sheet_write.py
@@ -1,0 +1,49 @@
+import os
+import sys
+from datetime import datetime, timezone
+
+from google.auth import default as google_auth_default
+from google.auth.transport.requests import Request as GARequest
+from googleapiclient.discovery import build
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def main() -> None:
+    sheet_id = os.environ.get("SHEET_ID", "").strip()
+    if not sheet_id:
+        print('...[ERROR] [verify] step=sheet_write ok=false reason="missing SHEET_ID"')
+        sys.exit(2)
+
+    tab = os.environ.get("SHEET_TAB", "smoke").strip() or "smoke"
+    cell = os.environ.get("SHEET_CELL", "A1").strip() or "A1"
+    value = os.environ.get("SHEET_VALUE", "").strip()
+    if not value:
+        value = f"smoke-test {_utc_now_iso()}"
+
+    range_a1 = f"{tab}!{cell}"
+
+    try:
+        creds, _ = google_auth_default(scopes=["https://www.googleapis.com/auth/spreadsheets"])
+        if not creds.valid:
+            creds.refresh(GARequest())
+        svc = build("sheets", "v4", credentials=creds, cache_discovery=False)
+        svc.spreadsheets().values().update(
+            spreadsheetId=sheet_id,
+            range=range_a1,
+            valueInputOption="USER_ENTERED",
+            body={"values": [[value]]},
+        ).execute()
+        print(f'...[INFO] [verify] step=sheet_write ok=true range="{range_a1}" value="{value}"')
+    except Exception as exc:  # pragma: no cover - best effort smoke path
+        print(
+            '...[ERROR] [verify] step=sheet_write ok=false '
+            f'reason="{exc.__class__.__name__}: {str(exc).strip()}"'
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a smoke test helper that writes a timestamp to a configurable Google Sheets cell
- document how to invoke the helper so operators can confirm edit access before running jobs

## Patch Map
- README.md: describe the new smoke write helper and its defaults
- tools/verify/smoke_sheet_write.py: new script that performs an authenticated write using ADC credentials

## Tests / CI
- `python -m compileall tools/verify`

## Rollback
- Revert this commit with `git revert <commit>` and delete any smoke-test data from the target sheet if necessary.

## Security
- relies on existing ADC / WIF credentials; no secrets added or modified.


------
https://chatgpt.com/codex/tasks/task_e_68d1a8ca0b8c8321bca60bc0a821d334