### PR TITLE
Fix Sheets clear payload for replace mode jobs

### DIFF
--- a/a_apps/a01_bsp_pullDaily_sheet_full/main.py
+++ b/a_apps/a01_bsp_pullDaily_sheet_full/main.py
@@ -493,7 +493,7 @@ def clear_data_rows(svc, sheet_id: str, tab: str):
     svc.spreadsheets().values().clear(
         spreadsheetId=sheet_id,
         range=f"{tab}!A2:ZZZ",
-        body={"requestBody": {}}
+        body={}
     ).execute()
 
 def append_rows(svc, sheet_id: str, tab: str, matrix: List[List]):

--- a/a_apps/a02_obb_macro_sheet/main.py
+++ b/a_apps/a02_obb_macro_sheet/main.py
@@ -52,7 +52,7 @@ def clear_data_rows(svc, sheet_id: str, tab: str):
     svc.spreadsheets().values().clear(
         spreadsheetId=sheet_id,
         range=f"{tab}!A2:H",
-        body={"requestBody": {}}
+        body={}
     ).execute()
 
 def append_rows(svc, sheet_id: str, tab: str, matrix: List[List[Any]]):


### PR DESCRIPTION
## Patch Map
- `a_apps/a01_bsp_pullDaily_sheet_full/main.py`: call Sheets clear with `{}` so replace-mode cleanup uses the expected payload.
- `a_apps/a02_obb_macro_sheet/main.py`: same fix for the macro sheet job.

## Tests/CI
- ✅ Inline verify harness (mocked Sheets client) confirming both helpers send `body={}`.

  ```bash
  python - <<'PY'
  from unittest.mock import Mock
  from a_apps.a01_bsp_pullDaily_sheet_full.main import clear_data_rows as clear_full
  from a_apps.a02_obb_macro_sheet.main import clear_data_rows as clear_macro

  def run_check(func):
      svc = Mock()
      clear_mock = svc.spreadsheets.return_value.values.return_value.clear
      clear_mock.return_value.execute.return_value = None
      func(svc, 'sheet', 'tab')
      body = clear_mock.call_args.kwargs.get('body')
      status = 'PASS' if body == {} else 'FAIL'
      print(f'...[{status}] [verify] helper={func.__module__}.{func.__name__} body={body}')
      if status != 'PASS':
          raise SystemExit(1)

  run_check(clear_full)
  run_check(clear_macro)
  PY
  ```

## Rollback Plan
- Revert commit `ade54a8` (`git revert ade54a8`) and redeploy the prior revision.

## Security Notes
- No secrets or IAM scopes changed; verification uses mocks only.


------
https://chatgpt.com/codex/tasks/task_e_68d1bd4b5a688321978f185dcf0d01cd