### PR TITLE
docs: update changelog for workflow coverage

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Changelog
 
 > Updates are recorded per release; initialized for docs guard workflow.
+
+## 2024-05-25
+- Documented the `_bq_bootstrap.yml` workflow and `tools/bq/bootstrap.sql` dataset bootstrap covering `trading`, `ohlcv_1d`, and `features_1d` tables.
+- Recorded the Cloud Run Jobs timeout flag change to `--task-timeout` and the execution URL echo added after job runs.


### PR DESCRIPTION
## Patch Map
- docs/CHANGELOG.md: record the BigQuery bootstrap workflow and Cloud Run timeout notes so docs guard sees a documentation touch.

## Tests/CI
- Not run; docs-only change.

## Rollback Plan
- Revert commit 9db31cc7abf7500a1d772e81da565ff1713a7ab4 if the guard change is no longer required.

## Security Notes
- No secrets or credentials added; documentation update only.

------
https://chatgpt.com/codex/tasks/task_e_68d80f666a088321b6837b062b36aafd