### PR TITLE
Add manual trigger for docs guard workflow

### DIFF
--- a/.github/workflows/docs-guard.yml
+++ b/.github/workflows/docs-guard.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'docs/**'
       - 'README.md'
+  workflow_dispatch:
 
 jobs:
   ensure-docs:


### PR DESCRIPTION
## Summary
- enable manual workflow_dispatch trigger for the Docs Guard workflow while keeping doc-specific PR paths

## Patch Map
- `.github/workflows/docs-guard.yml`: add workflow_dispatch trigger so the workflow can be invoked manually if needed

## Testing / CI
- `python - <<'PY' ...` (PASS) – verified workflow_dispatch hook and continue-on-error flag are present

## Rollback Plan
- Revert this commit to remove the workflow_dispatch trigger

## Security Notes
- No secrets added or modified; workflow scope unchanged

------
https://chatgpt.com/codex/tasks/task_e_68d819187b888321a8095b7d6aa9a389